### PR TITLE
Fixed relative image path, English Makefile; updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vim for humans
 
-## Installation
+## Install
 
 Be sure to create a symlink named 'vim-for-humans' in the project directory. This symlink should point to a directory where you've cloned [code examples](https://github.com/vjousse/vim-for-humans).
 
@@ -11,6 +11,17 @@ You will need some prerequisites to be able to compile the LaTeX source code:
 - [Sphinx](http://sphinx-doc.org/) to generate the epub file.
 - [kindlegen](http://www.amazon.com/gp/feature.html?docId=1000765211) to generate the .mobi file.
 
-## Compiling
+### Gentoo
 
-If you've installed everything, running the `makedist.sh` script should do the trick. If not, be sure to check the content of the script and to run each command one after another.
+* dev-python/sphinx[latex]
+* dev-python/pygments
+* app-text/texlive
+* kindlegen package not available.
+
+## Compile
+
+After the dependencies have been installed, create the dist directory via `mkdir dist` then run `makedist.sh` script to start compiling. The compilation fails be sure to check the content of the script and try running each command one after another.
+
+## Enjoy
+
+Upon success outputs can be found in the `dist/vimpourleshumains/` directory. Enjoy!

--- a/rst/en/Makefile
+++ b/rst/en/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build2
+SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
 

--- a/rst/en/plugins.rst
+++ b/rst/en/plugins.rst
@@ -76,7 +76,7 @@ Once the modification made and taken into account by |vim| (by restarting |vim| 
 
 .. _lusty:
 
-.. image:: ../book-tex/graphics/vim-lusty.png
+.. image:: ../../book-tex/graphics/vim-lusty.png
 
 The next thing to do is to deactivate *The Nerd Tree* by commenting the corresponding line like I have done on the screenshot above. It will not be useful anymore as *Lusty Explorer* is a better replacement when using the keyboard.
 
@@ -86,7 +86,7 @@ You can see on the `lusty`_ screenshot that *Lusty Explorer* is made of two part
 
 .. _fuzzy:
 
-.. image:: ../book-tex/graphics/vim-lusty-fuzzy.png
+.. image:: ../../book-tex/graphics/vim-lusty-fuzzy.png
 
 
 Here are some handy handy shortcuts of *Lusty Explorer*:
@@ -143,7 +143,7 @@ Ack will start the search from the directory of the file currently opened. Here 
 
 The results will be displayed in a window called the *Quickfix Window*, as you can see below.
 
-.. image:: ../book-tex/graphics/vim-ack-quickfix.png
+.. image:: ../../book-tex/graphics/vim-ack-quickfix.png
 
 Here are some commands available inside this window:
 
@@ -204,7 +204,7 @@ Now we need to add the shortcut to our |vimrc| to invoke CtrlP like in the listi
 
 Here is CtrlP in action.
 
-.. image:: ../book-tex/graphics/vim-ctrlp.png
+.. image:: ../../book-tex/graphics/vim-ctrlp.png
 
 Launch it with ``,c`` and then type the name of the file you want to search. When the searched file will be selected first, you will just have to press |ttenter| to open it.
 

--- a/rst/en/text-manip.rst
+++ b/rst/en/text-manip.rst
@@ -40,7 +40,7 @@ To copy/past using |vim|, you will have to switch to the "normal" mode (the defa
 
 .. _mode insert:
 
-.. image:: ../book-tex/graphics/vim-insert.png
+.. image:: ../../book-tex/graphics/vim-insert.png
 
 
 When there is nothing displayed at the bottom left, it's because you are currently in "normal" mode. In order to quit a mode to return to the normal one, you just have to press |ttesc|. You may already have noticed that pressing |ttesc| is a pain for your fingers. No worries, it's just a temporary thing, I will explain why in the ":ref:`secesc`" section.
@@ -49,7 +49,7 @@ Let's say that you are currently in the "normal" mode and that you already have 
 
 .. _twain:
 
-.. image:: ../book-tex/graphics/vim-twain.png
+.. image:: ../../book-tex/graphics/vim-twain.png
 
 The most intuitive way (but not the most efficient, we will see why a little bit later) to copy/paste the "impossible" word is to move the cursor at the first letter of the word using the directional keys, to press |ttv| (to switch to the "visual" mode), to move to the last letter of the word (you should have the word "impossible" highlighted) and then to press |tty| (|tty| stands for *yank*). You've just copied your first word using |vim|. Hooray!
 
@@ -57,7 +57,7 @@ Then, move to the end of the sentence (in "normal" mode) and press |ttp| (|ttp| 
 
 .. _vim-paste:
 
-.. image:: ../book-tex/graphics/vim-paste.png
+.. image:: ../../book-tex/graphics/vim-paste.png
 
 We can see that |vim| uses the mode switching trick (including the "normal" mode for moving) in order to not have to use the mouse.
 When you will be used to switch quickly from one mode to another (and in order to do so, going without |ttesc| will be mandatory), using the mouse will appear like a pure waste of time. But obviously, you will first need to train yourself.
@@ -84,7 +84,7 @@ When in normal mode, 4 keys will allow you to move your cursor:
 
 .. _hjkl:
 
-.. image:: ../book-tex/graphics/hjkl.png
+.. image:: ../../book-tex/graphics/hjkl.png
 
 As you can notice, those keys are located on the home row so that you don't have to move your hands. Your index has two moves (left and bottom) while your auricular doesn't have any. You will see that it's not a problem, it's even a feature: your index is stronger than your auricular. By checking the keyboard that was used to develop *Vi* in the ":ref:`secesc`" section, you will understand why.
 
@@ -139,7 +139,7 @@ Here is an handy graphical cheat sheet that you can download on http://www.viemu
 
 .. _cheat-sheet:
 
-.. image:: ../book-tex/graphics/vi-vim-cheat-sheet.png
+.. image:: ../../book-tex/graphics/vi-vim-cheat-sheet.png
 
 Keep in mind that the main goal here is to increase your speed while keeping your hands on the "home row" and using the "normal mode". Get down to work!
 
@@ -154,7 +154,7 @@ To understand why |ttesc| is used by default to exit the "insert mode", we have 
 
 .. _vi-keyboard:
 
-.. image:: ../book-tex/graphics/lsi-adm3a-full-keyboard.jpg
+.. image:: ../../book-tex/graphics/lsi-adm3a-full-keyboard.jpg
 
 So we agree that we need another key to exit the insert mode. There are many solutions, here are some possibilities that you can try in your |vimrc|: ::
 
@@ -316,6 +316,6 @@ To awaken the child in you, I urge you to go have fun with http://vim-adventures
 
 .. _vim-adventures:
 
-.. image:: ../book-tex/graphics/vim-adventures.png
+.. image:: ../../book-tex/graphics/vim-adventures.png
 
 Now we will go to the next level: the use of plugins, or how to make |vim| indispensable.

--- a/rst/en/usable-vim.rst
+++ b/rst/en/usable-vim.rst
@@ -16,7 +16,7 @@ Here is what a default |vim| is missing (and why **most of people are giving up*
 
     |solarized|
 
-.. |solarized| image:: ../book-tex/graphics/solarized-yinyang-mini.png
+.. |solarized| image:: ../../book-tex/graphics/solarized-yinyang-mini.png
 
 **File explorer**
     If your are using |vim| along with a graphical interface (I suppose it's the case for 99% of you) you will by default have a ``File`` menu available. This menu should allow you to open a file. It's, for sure, a good start. But having a file explorer a la Netbeans or Textmate can be very handy. To mimic the same behavior, we will be using `The NERD Tree <http://www.vim.org/scripts/script.php?script_id=1658>`_. Be aware that, once you will have read this guide, you will not need the mouse anymore.
@@ -38,7 +38,7 @@ The first thing to do will certainly be to install a |vim| version for your oper
 
 When you will start |vim|, you should see a welcome text asking you to help poor children in Uganda (or something along the lines). 
 
-.. image:: ../book-tex/graphics/en/vim-uganda.png
+.. image:: ../../book-tex/graphics/en/vim-uganda.png
 
 This text will disappear as soon as we will be writing text in |vim|. 
 
@@ -46,7 +46,7 @@ We will start by adding a comment in the header of the file to specify the autho
 
 .. _a blank page:
 
-.. image:: ../book-tex/graphics/en/vim-new.png
+.. image:: ../../book-tex/graphics/en/vim-new.png
 
 **On a side note**: if you don't really understand what you have done and |vim| is displaying red messages at the bottom left or doesn't seem to react as it should when you press |tti|, don't panic. Pressing multiples times on |ttesc| (two times should be enough) should bring |vim| to its default mode, the *Normal mode*. Then it should behave as you would expect again.
 
@@ -60,7 +60,7 @@ You should know be able to write down `the comment below`_:
 
 You will have noticed that comments in *VimL* (the name of the |vim| programing language) start with a :viml:`"`. Then press |ttesc| to come back to the default mode (the normal mode) of |vim|. That's all, you are done. Here is a screenshot of what your |vim| should look like now:
 
-.. image:: ../book-tex/graphics/en/vim-first-comment.png
+.. image:: ../../book-tex/graphics/en/vim-first-comment.png
 
 I can already hear you: all that fuss for that? Well, yes. And you even don't know how to save a file. But all these things are logical that I'm gonna explain to you. One of the advantages of |vim| is that, usually, it is logical. Once you will have understood the logic behind it, all will be crystal clear for you (at least I hope so).
 
@@ -83,7 +83,7 @@ So what do you have the right to do? Not a lot to be honest (but it's for your o
 
 .. _as you can see on the picture below:
 
-.. figure:: ../book-tex/graphics/hand-position.png
+.. figure:: ../../book-tex/graphics/hand-position.png
    
    Home row, QWERTY keyboard
 
@@ -128,7 +128,7 @@ Below is a screenshot of |vim| (macvim) `after your first configuration`_.
 
 .. _after your first configuration:
 
-.. figure:: ../book-tex/graphics/en/vim-first-config.png
+.. figure:: ../../book-tex/graphics/en/vim-first-config.png
 
    |vim| after your first configuration.
 
@@ -151,7 +151,7 @@ First, we need to enable syntax highlighting in the configuration file. Add thes
 You should have a |vim| looking like the picture below.
 
 
-.. figure:: ../book-tex/graphics/vim-syntax-hl.png
+.. figure:: ../../book-tex/graphics/vim-syntax-hl.png
 
    Default syntax highlighting.
 
@@ -163,7 +163,7 @@ Themes will allow you to have a nicer |vim| than the default one. A theme will c
 
 To install it, you will first need to create a directory called `.vim` in the same directory than your |vimrc| (that is to say, in your home directory). Note that when using Windows, the `.vim` directory is called `vimfiles`. Each time I'll be speaking of the `.vim` directory, it will be the `vimfiles` directory for people using Windows. In this `.vim` directory, create a sub directory named `colors`. Then, download the *Solarized* theme file https://raw.github.com/altercation/vim-colors-solarized/master/colors/solarized.vim (it's the same file for the light and the dark version) and copy it in your `vim/colors/` directory. You `.vim` directory should look like the picture below.
 
-.. figure:: ../book-tex/graphics/solarized-tree.png
+.. figure:: ../../book-tex/graphics/solarized-tree.png
 
    Content of the .vim directory with Solarized.
 
@@ -177,12 +177,12 @@ To test the light theme, you just have to change `dark` with `light` (for the `b
 
 Here is a preview of the two versions (personally, I prefer the dark one).
 
-.. figure:: ../book-tex/graphics/vim-solarized-dark.png
+.. figure:: ../../book-tex/graphics/vim-solarized-dark.png
 
    The dark  *Solarized* theme.
 
 
-.. figure:: ../book-tex/graphics/vim-solarized-light.png
+.. figure:: ../../book-tex/graphics/vim-solarized-light.png
 
    The light  *Solarized* theme.
 
@@ -222,7 +222,7 @@ The main problem with this approach is that the plugins are not isolated. So you
 
 That's why *Pathogen* is especially useful, it will allow each plugin to be located in a separate directory. Here is an example of a |.vim| directory before and after the usage of *Pathogen*:
 
-.. figure:: ../book-tex/graphics/pathogen-tree.png
+.. figure:: ../../book-tex/graphics/pathogen-tree.png
 
    |.vim| before and after Pathogen
 
@@ -308,7 +308,7 @@ I have to admit that this command is a little bit obscure. Actually it means: ev
 
 Nothing special then, *The NERD Tree* will display the tree of the directory where you've launched |vim| as you can see on the picture below. You can use your mouse and/or your keyboard to move inside *The NERD Tree*.
 
-.. figure:: ../book-tex/graphics/vim-nerdtree.png
+.. figure:: ../../book-tex/graphics/vim-nerdtree.png
 
    |vim| with *The NERD Tree*.
 


### PR DESCRIPTION
English side of things was in a state of disarray. I believe I have improved things by fixing relative image paths and migrating SPHINXBUILD to `sphinx-build` in `rst/en/Makefile` It built fine for me! I also updated the README with explicit build deps for those trying to build the ebook on Gentoo.

If you create an official release (using git tags) I can create an ebuild. Thanks for sharing this work with us!
