### PR TITLE
Cleaned up distribution script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You will need some prerequisites to be able to compile the LaTeX source code:
 
 ## Compile
 
-After the dependencies have been installed, create the dist directory via `mkdir dist` then run `makedist.sh` script to start compiling. The compilation fails be sure to check the content of the script and try running each command one after another.
+After the dependencies have been installed, run `makedist.sh` script to start compiling. If the compilation fails, be sure to check the content of the script and try running each command one after another.
 
 ## Enjoy
 

--- a/makedist.sh
+++ b/makedist.sh
@@ -1,15 +1,19 @@
-#cd book-tex/
-#pdflatex -shell-escape vim-pour-les-humains.tex
-#pdflatex -shell-escape vim-pour-les-humains.tex
+# Create dist/ if necessary
+mkdir -p dist
+
+# Create French Directory
 cd rst/fr
 make clean
 make epub
+
+# Create English Directory
 cd ../en
 make clean
 make epub
 make latexpdf
 cd ../../dist
 
+# Make Distribution 
 ts=`date +%s`
 mkdir $ts
 cd ..
@@ -18,8 +22,12 @@ cp rst/fr/_build/epub/Vimpourleshumains.epub dist/$ts/vim-pour-les-humains.epub
 cp rst/en/_build/epub/Vimforhumans.epub dist/$ts/vim-for-humans.epub
 cp rst/en/_build/latex/Vimforhumans.pdf dist/$ts/vim-for-humans.pdf
 cd dist/$ts
+
+# Create Kindle Versions 
 kindlegen vim-pour-les-humains.epub
 kindlegen vim-for-humans.epub
+
+# Zip 
 cd ..
 rm -rf vimpourleshumains/
 rm vimpourleshumains.zip


### PR DESCRIPTION
# Changes

I added `mkdir -p dist` to the `makedist.sh` script. This line creates the `dist` directory only if it doesn't exist. I then updated `README.md` to reflect this change (the user doesn't need to manually create this directory). 
# Fixes

Added some comments to the `makedist.sh` script
