### PR TITLE
Replace |tP| with ``P``

### DIFF
--- a/rst/en/conf.py
+++ b/rst/en/conf.py
@@ -136,6 +136,7 @@ rst_epilog = u"""
 .. |to| replace:: ``o``
 .. |tO| replace:: ``O``
 .. |tp| replace:: ``p``
+.. |tP| replace:: ``P``
 .. |tu| replace:: ``u``
 .. |tr| replace:: ``r``
 .. |tv| replace:: ``v``

--- a/rst/fr/conf.py
+++ b/rst/fr/conf.py
@@ -133,6 +133,7 @@ rst_epilog = u"""
 .. |to| replace:: ``o``
 .. |tO| replace:: ``O``
 .. |tp| replace:: ``p``
+.. |tP| replace:: ``P``
 .. |tu| replace:: ``u``
 .. |tr| replace:: ``r``
 .. |tv| replace:: ``v``


### PR DESCRIPTION
Hello @vjousse 
in the subsection `Combining keys and moves` is the sentence ```All you have to do next is to press the `p` key to paste the text you have copied above. By default, the `p` key will paste the text after the current position of the cursor. If you want to paste before the position of the cursor, use the `p` key.```.
I guess the last `p` should be `P`. I hope my changes will fix that.